### PR TITLE
Add missing dependency on Str

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,4 @@
  (name CoreAndMore)
  (public_name core-and-more)
  (preprocess (pps ppx_hash ppx_sexp_conv ppx_bin_prot ppx_deriving.std))
- (libraries core posix-math))
+ (libraries core posix-math str))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.